### PR TITLE
Use layout instead of page

### DIFF
--- a/_includes/JB/setup
+++ b/_includes/JB/setup
@@ -17,7 +17,7 @@
     {% if site.JB.ASSET_PATH %}
       {% assign ASSET_PATH = site.JB.ASSET_PATH %}
     {% else %}
-      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ page.theme.name }}{% endcapture %}
+      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ layout.theme.name }}{% endcapture %}
     {% endif %}  
   {% endif %}
 {% endcapture %}{% assign jbcache = nil %}


### PR DESCRIPTION
In Jekyll 3.1, layout-defined variables are not munged onto the `page` object, but rather accessible via `{{ layout }}`. `_layouts/default.html`, and the other layouts define the theme, so this variable must be updated accordingly.
